### PR TITLE
fix incorrect timezone

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ class WorkingTimeCalculator extends EventEmitter {
     }
 
     excludeBetween(date1, date2, reason = 'Custom Exclusion') {
-        date1 = (date1 instanceof Date) ? DateTime.fromJSDate(date1) : DateTime.fromISO(date1);
-        date2 = (date2 instanceof Date) ? DateTime.fromJSDate(date2) : DateTime.fromISO(date2);
+        date1 = (date1 instanceof Date) ? DateTime.fromJSDate(date1) : DateTime.fromISO(date1, {setZone: true});
+        date2 = (date2 instanceof Date) ? DateTime.fromJSDate(date2) : DateTime.fromISO(date2, {setZone: true});
         this._customExclusions.push({start: date1, end: date2, reason});
     }
 
@@ -135,8 +135,8 @@ class WorkingTimeCalculator extends EventEmitter {
     }
 
     calcDurationBetween(date1, date2) {
-        date1 = (date1 instanceof Date) ? DateTime.fromJSDate(date1) : DateTime.fromISO(date1);
-        date2 = (date2 instanceof Date) ? DateTime.fromJSDate(date2) : DateTime.fromISO(date2);
+        date1 = (date1 instanceof Date) ? DateTime.fromJSDate(date1) : DateTime.fromISO(date1, {setZone: true});
+        date2 = (date2 instanceof Date) ? DateTime.fromJSDate(date2) : DateTime.fromISO(date2, {setZone: true});
 
         const startDate = date1 > date2 ? date2 : date1;
         const endDate = date1 > date2 ? date1 : date2;


### PR DESCRIPTION
I recently found an issue that if a machine's local timezone is different from the timezone given in the ISO string. Incorrect working time calculation would be made.

For example, given a local timezone is +8 and a timezone from an ISO string is +12, the `DateTime` created by `DateTime.fromISO()` would be +8, the `date.weekday` could be offset by 1 or -1.

By adding `{setZone: true}` when creating `date1` and `date2` fixed this problem.