### PR TITLE
fix _timeToUnits to stable WHSTART

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ class WorkingTimeCalculator extends EventEmitter {
         if (Number.isNaN(seconds)) {
             seconds = 0;
         }
-        return {hour, minute, seconds};
+        return {hour, minute, seconds, milliseconds: 0};
     }
 
     _getExclusionMarkers(start, end) {


### PR DESCRIPTION
When the input of calcDurationBetween 'date1' contains milliseconds, the WHSTART will be shifted by the milliseconds of date1.